### PR TITLE
add requirements.in to resources

### DIFF
--- a/myst.yml
+++ b/myst.yml
@@ -32,6 +32,7 @@ project:
     published: 2025-01-31
   requirements:
     - 'Dockerfile'
+    - requirements.in
   resources:
     - 'notebooks/**/*'
   references:


### PR DESCRIPTION
the `requirements.in` is not bundled into the MECA so is not available to copy in Dockerfile